### PR TITLE
make hull_area return consistent type; use extend instead of append i…

### DIFF
--- a/freedom/reco/i3freedom.py
+++ b/freedom/reco/i3freedom.py
@@ -161,8 +161,7 @@ def store_dllh(frame, prefix, full_res, no_track_res, E_only_res):
 def to_i3_vec(array, i3_vec_type):
     """convert a list/array to an I3Vec"""
     i3_vec = i3_vec_type()
-    for val in array:
-        i3_vec.append(val)
+    i3_vec.extend(array)
     return i3_vec
 
 

--- a/freedom/reco/postfit.py
+++ b/freedom/reco/postfit.py
@@ -145,7 +145,7 @@ def hull_area(par, llhs, above_min=1):
         Hull = ConvexHull(np.stack([par, llhs]).T[llhs < min_llh+above_min])
         return Hull.volume
     except QhullError:
-        return None
+        return np.inf
 
 
 def furthest_point(par, llhs, above_min=2):


### PR DESCRIPTION
…n to_i3_vec

The postfit result arrays are converted directly into `I3VectorDoubles` during the i3reco process. For this to work most easily, the postfit functions should always return floats, not `None`. (One of my recent reco jobs crashed when it tried to push a `None` into an `I3VectorDouble`.)  