### PR TITLE
remove __author__ assignments

### DIFF
--- a/freedom/llh_service/cpu_client.py
+++ b/freedom/llh_service/cpu_client.py
@@ -11,8 +11,6 @@ available.
 
 from __future__ import absolute_import, division, print_function
 
-__author__ = "Aaron Fienberg"
-
 import numpy as np
 
 import tensorflow as tf

--- a/freedom/llh_service/eval_llh.py
+++ b/freedom/llh_service/eval_llh.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-__author__ = "Aaron Fienberg"
-
 import tensorflow as tf
 
 

--- a/freedom/llh_service/llh_client.py
+++ b/freedom/llh_service/llh_client.py
@@ -6,8 +6,6 @@ provides synchronous and asynchronous interfaces
 
 from __future__ import absolute_import, division, print_function
 
-__author__ = "Aaron Fienberg"
-
 import uuid
 
 import numpy as np

--- a/freedom/llh_service/llh_cython.pyx
+++ b/freedom/llh_service/llh_cython.pyx
@@ -6,8 +6,6 @@ cython accelerated send/recv functions for use with the LLH service and client
 """
 
 
-__author__ = "Aaron Fienberg"
-
 import numpy as np
 
 cimport numpy as np

--- a/freedom/llh_service/llh_service.py
+++ b/freedom/llh_service/llh_service.py
@@ -7,8 +7,6 @@ listens for llh evaluation requests and processes them in batches
 
 from __future__ import absolute_import, division, print_function
 
-__author__ = "Aaron Fienberg"
-
 import os
 import time
 import sys

--- a/freedom/reco/bounds.py
+++ b/freedom/reco/bounds.py
@@ -2,8 +2,6 @@
 Provides functions for parameter bounds checking during LLH evaluations
 """
 
-__author__ = "Aaron Fienberg"
-
 import numpy as np
 
 NAN_REPLACE_VAL = 1e10

--- a/freedom/reco/crs_reco.py
+++ b/freedom/reco/crs_reco.py
@@ -4,7 +4,6 @@ Fitting functions for CRS2-based FreeDOM event reconstruction
 Also provides a main() function to drive a CRS2-based reconstruction job
 """
 
-__author__ = "Aaron Fienberg"
 
 import argparse
 import pickle

--- a/freedom/reco/postfit.py
+++ b/freedom/reco/postfit.py
@@ -3,7 +3,6 @@ Provides "postfit" functions. Postfits analyze the minimizer samples
 to provide alternative parameter estimates and uncertainty estimates
 """
 
-__author__ = "Aaron Fienberg"
 
 import numpy as np
 from numpy.polynomial import polynomial as poly, Polynomial

--- a/freedom/reco/prefit.py
+++ b/freedom/reco/prefit.py
@@ -3,7 +3,6 @@ Provides "prefit" functions. Prefits give initial guesses that can be used
 to seed llh optimizers and samplers
 """
 
-__author__ = "Aaron Fienberg"
 
 import numpy as np
 

--- a/freedom/reco/summary_df.py
+++ b/freedom/reco/summary_df.py
@@ -2,7 +2,6 @@
 Provides functions for converting FreeDOM fit results into pandas dataframes
 """
 
-__author__ = "Aaron Fienberg"
 
 import pandas as pd
 


### PR DESCRIPTION
`__author__ = "Aaron Fienberg"` is misleading at best. Most of these files have numerous contributors at this point. We can use git to tell us who wrote which part of the code, so I have removed the `__author__` assignments. 